### PR TITLE
Scaffold the Rust project

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "dapr"
+version = "0.1.0"
+authors = ["dapr.io"]
+edition = "2018"
+
+[dependencies]
+tonic = "0.1.0-alpha.4"
+prost = "0.5"
+bytes = "0.4"
+prost-types = "0.5"
+
+[build-dependencies]
+tonic-build = "0.1.0-alpha.4"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,7 @@ tonic = "0.1.0-alpha.4"
 prost = "0.5"
 bytes = "0.4"
 prost-types = "0.5"
+tokio = "0.2.0-alpha.6"
 
 [build-dependencies]
 tonic-build = "0.1.0-alpha.4"
-
-[dev-dependencies]
-tokio = "0.2.0-alpha.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ prost = "0.5"
 bytes = "0.4"
 prost-types = "0.5"
 tokio = "0.2.0-alpha.6"
+async-trait = "0.1.17"
 
 [build-dependencies]
 tonic-build = "0.1.0-alpha.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ prost-types = "0.5"
 [build-dependencies]
 tonic-build = "0.1.0-alpha.4"
 
+[dev-dependencies]
+tokio = "0.2.0-alpha.6"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,25 @@
 # Dapr SDK for Rust
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 ⚠ Work in Progress ⚠
 
 Dapr is a portable, event-driven, serverless runtime for building distributed applications across cloud and edge.
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-
 - [dapr.io](https://dapr.io)
 - [@DaprDev](https://twitter.com/DaprDev)
+
+## Usage
+
+## Building
+
+The Rust SDK depends on async/await which will only become stable in the 1.39.0 version
+of the language, slated for release in early Novemeber. That means a nightly or beta version
+of the compiler is required.
+
+To build
+
+```bash
+cargo +beta build
+```
+>>>>>>> Beginnings of dapr client

--- a/README.md
+++ b/README.md
@@ -22,4 +22,3 @@ To build
 ```bash
 cargo +beta build
 ```
->>>>>>> Beginnings of dapr client

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Dapr is a portable, event-driven, serverless runtime for building distributed ap
 
 ## Usage
 
+TBD
+
 ## Building
 
 The Rust SDK depends on async/await which will only become stable in the 1.39.0 version

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,12 @@
+fn main() -> Result<(), std::io::Error> {
+    for entry in std::fs::read_dir("proto")? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            panic!("Subdirectories in the proto directory are not currently supported")
+        }
+
+        tonic_build::compile_protos(path).unwrap();
+    }
+    Ok(())
+}

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,0 +1,14 @@
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Get the Dapr port and create a connection
+    let port: u16 = std::env::var("DAPR_GRPC_PORT")?.parse()?;
+    let addr = format!("https://127.0.0.1:{}", port);
+
+    // Create the client
+    let mut client = dapr::Client::connect(addr)?;
+
+    // Invoke a method called MyMethod on another Dapr enabled service with id client
+    let res = client.invoke_service("client", "my_method", None).await?;
+
+    Ok(())
+}

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -5,7 +5,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = format!("https://127.0.0.1:{}", port);
 
     // Create the client
-    let mut client = dapr::Client::connect(addr)?;
+    let mut client = dapr::Client::connect(addr).await?;
 
     // Invoke a method called MyMethod on another Dapr enabled service with id client
     let res = client.invoke_service("client", "my_method", None).await?;

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -5,7 +5,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = format!("https://127.0.0.1:{}", port);
 
     // Create the client
-    let mut client = dapr::Client::connect(addr).await?;
+    let mut client = dapr::Client::<dapr::client::TonicClient>::connect(addr).await?;
 
     // Invoke a method called MyMethod on another Dapr enabled service with id client
     let res = client.invoke_service("client", "my_method", None).await?;

--- a/proto/dapr.proto
+++ b/proto/dapr.proto
@@ -1,0 +1,106 @@
+syntax = "proto3";
+
+package dapr;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/duration.proto";
+
+option java_outer_classname = "DaprProtos";
+option java_package = "io.dapr";
+
+option csharp_namespace = "Dapr.Client.Grpc";
+
+
+// Dapr definitions
+service Dapr {
+  rpc PublishEvent(PublishEventEnvelope) returns (google.protobuf.Empty) {}
+  rpc InvokeService(InvokeServiceEnvelope) returns (InvokeServiceResponseEnvelope) {}
+  rpc InvokeBinding(InvokeBindingEnvelope) returns (google.protobuf.Empty) {}
+  rpc GetState(GetStateEnvelope) returns (GetStateResponseEnvelope) {}
+  rpc SaveState(SaveStateEnvelope) returns (google.protobuf.Empty) {}
+  rpc DeleteState(DeleteStateEnvelope) returns (google.protobuf.Empty) {}
+}
+
+message InvokeServiceResponseEnvelope {
+  google.protobuf.Any data = 1;
+  map<string,string> metadata = 2;
+}
+
+message DeleteStateEnvelope {
+  string key = 1;
+  string etag = 2;
+  StateOptions options = 3;
+}
+
+message SaveStateEnvelope {
+  repeated StateRequest requests = 1;
+}
+
+message GetStateEnvelope {
+    string key = 1;
+    string consistency = 2;
+}
+
+message GetStateResponseEnvelope {
+  google.protobuf.Any data = 1;
+  string etag = 2;
+}
+
+message InvokeBindingEnvelope {
+  string name = 1;
+  google.protobuf.Any data = 2;
+  map<string,string> metadata = 3;
+}
+
+message InvokeServiceEnvelope {
+  string id = 1;
+  string method = 2;
+  google.protobuf.Any data = 3;
+  map<string,string> metadata = 4;
+}
+
+message PublishEventEnvelope {
+    string topic = 1;
+    google.protobuf.Any data = 2;
+}
+
+message State {
+  string key = 1;
+  google.protobuf.Any value = 2;
+  string etag = 3;
+  map<string,string> metadata = 4;
+  StateOptions options = 5;
+}
+
+message StateOptions {
+  string concurrency = 1;
+  string consistency = 2;
+  RetryPolicy retryPolicy = 3;
+}
+
+message RetryPolicy {
+  int32 threshold = 1;
+  string pattern = 2;
+  google.protobuf.Duration interval = 3;
+}
+
+message StateRequest {
+  string key = 1;
+  google.protobuf.Any value = 2;
+  string etag = 3;
+  map<string,string> metadata = 4;
+  StateRequestOptions options = 5;
+}
+
+message StateRequestOptions {
+  string concurrency = 1;
+  string consistency = 2;
+  StateRetryPolicy retryPolicy = 3;
+}
+
+message StateRetryPolicy {
+  int32 threshold = 1;
+  string pattern = 2;
+  google.protobuf.Duration interval = 3;
+}

--- a/proto/daprclient.proto
+++ b/proto/daprclient.proto
@@ -1,0 +1,76 @@
+syntax = "proto3";
+
+package daprclient;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/duration.proto";
+
+option java_outer_classname = "DaprClientProtos";
+option java_package = "io.dapr";
+
+// User Code definitions
+service DaprClient {
+  rpc OnInvoke (InvokeEnvelope) returns (google.protobuf.Any) {}
+  rpc GetTopicSubscriptions(google.protobuf.Empty) returns (GetTopicSubscriptionsEnvelope) {}
+  rpc GetBindingsSubscriptions(google.protobuf.Empty) returns (GetBindingsSubscriptionsEnvelope) {}
+  rpc OnBindingEvent(BindingEventEnvelope) returns (BindingResponseEnvelope) {}
+  rpc OnTopicEvent(CloudEventEnvelope) returns (google.protobuf.Empty) {}
+}
+
+message CloudEventEnvelope {
+  string id = 1;
+  string source = 2;
+  string type = 3;
+  string specVersion = 4;
+  string dataContentType = 5;
+  string topic = 6;
+  google.protobuf.Any data = 7;
+}
+
+message BindingEventEnvelope {
+    string name = 1;
+    google.protobuf.Any data = 2;
+    map<string,string> metadata = 3;
+}
+
+message BindingResponseEnvelope {
+  google.protobuf.Any data = 1;
+  repeated string to = 2;
+  repeated State state = 3;
+  string concurrency = 4;
+}
+
+message InvokeEnvelope {
+    string method = 1;
+    google.protobuf.Any data = 2;
+    map<string,string> metadata = 3;
+}
+
+message GetTopicSubscriptionsEnvelope {
+  repeated string topics = 1;
+}
+
+message GetBindingsSubscriptionsEnvelope {
+  repeated string bindings = 1;
+}
+
+message State {
+  string key = 1;
+  google.protobuf.Any value = 2;
+  string etag = 3;
+  map<string,string> metadata = 4;
+  StateOptions options = 5;
+}
+
+message StateOptions {
+  string concurrency = 1;
+  string consistency = 2;
+  RetryPolicy retryPolicy = 3;
+}
+
+message RetryPolicy {
+  int32 threshold = 1;
+  string pattern = 2;
+  google.protobuf.Duration interval = 3;
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,17 +1,14 @@
+use async_trait::async_trait;
 use crate::error::Error;
 use prost_types::Any;
 use std::fmt;
 
-pub struct Client(internal::client::DaprClient<tonic::transport::Channel>);
+pub struct Client<T>(T);
 
-impl Client {
+impl <T: DaprInterface> Client<T> {
     /// Connect to a Dapr enabled app.
     pub async fn connect(addr: String) -> Result<Self, Error> {
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        std::thread::spawn(|| {
-            tx.send(internal::client::DaprClient::connect(addr).map(Client)).unwrap();
-        });
-        Ok(rx.await.unwrap()?)
+        T::connect(addr).await.map(Client)
     }
 
     /// Invoke a method in a Dapr enabled app.
@@ -25,23 +22,39 @@ impl Client {
         I: Into<String>,
         M: Into<String>,
     {
-        let res = self
+        self
             .0
-            .invoke_service(tonic::Request::new(internal::InvokeServiceEnvelope {
+            .invoke_service(InvokeServiceRequest {
                 id: app_id.into(),
                 method: method_name.into(),
                 data,
                 ..Default::default()
-            }))
-            .await?;
+            })
+            .await
 
-        Ok(res.into_inner())
     }
 }
 
-impl fmt::Debug for Client {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Client")
+#[async_trait]
+pub trait DaprInterface: std::marker::Sized {
+    async fn connect(addr: String) -> Result<Self, Error>;
+    async fn invoke_service(&mut self, request: InvokeServiceRequest) -> Result<InvokeServiceResponse, Error>;
+}
+
+
+#[async_trait]
+impl DaprInterface for internal::client::DaprClient<tonic::transport::Channel> {
+    async fn connect(addr: String) -> Result<Self, Error> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        std::thread::spawn(|| {
+            tx.send(internal::client::DaprClient::connect(addr)).unwrap_or_else(|_| panic!(""));
+        });
+        Ok(rx.await.unwrap_or_else(|_| panic!(""))?)
+
+    }
+
+    async fn invoke_service(&mut self, request: InvokeServiceRequest) -> Result<InvokeServiceResponse, Error> {
+        Ok(self.invoke_service(tonic::Request::new(request)).await?.into_inner())
     }
 }
 
@@ -50,5 +63,10 @@ mod internal {
     tonic::include_proto!("dapr");
 }
 
+/// A request from invoking a service
+pub type InvokeServiceRequest = internal::InvokeServiceEnvelope;
 /// A response from invoking a service
 pub type InvokeServiceResponse = internal::InvokeServiceResponseEnvelope;
+
+/// A tonic based gRPC client
+pub type TonicClient = internal::client::DaprClient<tonic::transport::Channel>;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,1 +1,41 @@
-tonic::include_proto!("daprclient");
+use crate::error::Error;
+use prost_types::Any;
+
+pub struct Client(internal::client::DaprClient<tonic::transport::Channel>);
+
+impl Client {
+    /// Connect to a Dapr enabled app.
+    pub fn connect(addr: String) -> Result<Self, Error> {
+        Ok(Client(internal::client::DaprClient::connect(addr)?))
+    }
+
+    /// Invoke a method in a Dapr enabled app.
+    pub async fn invoke_service<I, M>(
+        &mut self,
+        app_id: I,
+        method_name: M,
+        data: Option<Any>,
+    ) -> Result<InvokeServiceResponseEnvelope, Error>
+    where
+        I: Into<String>,
+        M: Into<String>,
+    {
+        let res = self
+            .0
+            .invoke_service(tonic::Request::new(internal::InvokeServiceEnvelope {
+                id: app_id.into(),
+                method: method_name.into(),
+                data,
+                ..Default::default()
+            }))
+            .await?;
+
+        Ok(res.into_inner())
+    }
+}
+
+mod internal {
+    tonic::include_proto!("dapr");
+}
+
+pub use internal::InvokeServiceResponseEnvelope;

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,7 +15,7 @@ impl Client {
         app_id: I,
         method_name: M,
         data: Option<Any>,
-    ) -> Result<InvokeServiceResponseEnvelope, Error>
+    ) -> Result<InvokeServiceResponse, Error>
     where
         I: Into<String>,
         M: Into<String>,
@@ -38,4 +38,5 @@ mod internal {
     tonic::include_proto!("dapr");
 }
 
-pub use internal::InvokeServiceResponseEnvelope;
+/// A response from invoking a service
+pub type InvokeServiceResponse = internal::InvokeServiceResponseEnvelope;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,1 @@
+tonic::include_proto!("daprclient");

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,34 @@
+#[derive(Debug)]
+pub enum Error {
+    TransportError,
+    GrpcError(GrpcError),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl std::convert::From<tonic::transport::Error> for Error {
+    fn from(error: tonic::transport::Error) -> Self {
+        Error::TransportError
+    }
+}
+
+impl std::convert::From<tonic::Status> for Error {
+    fn from(error: tonic::Status) -> Self {
+        Error::GrpcError(GrpcError {})
+    }
+}
+
+#[derive(Debug)]
+pub struct GrpcError {}
+
+impl std::fmt::Display for GrpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod client;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,4 @@
 pub mod client;
+mod error;
+
+pub use client::Client;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod client;
-mod error;
+pub mod error;
 
 pub use client::Client;


### PR DESCRIPTION
The beginnings of the crate. This simply gets a DaprClient struct in place that can invoke methods on a service. 

This differs from @flier's implementation in that it tries to hide the underlying gRPC library from the public API. This means that the user cannot rely on the fact that we're currently using the `tonic` crate. It also does not make the generated bindings public so the user can only use the hand written API built on top of the generated bindings. 

The error types in this PR are just stubs and need to be expanded out. 