### PR TITLE
Add more client methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,11 @@ authors = ["dapr.io"]
 edition = "2018"
 
 [dependencies]
-tonic = "0.1.0-alpha.4"
+tonic = "0.1.0-alpha.5"
 prost = "0.5"
 bytes = "0.4"
 prost-types = "0.5"
-tokio = "0.2.0-alpha.6"
 async-trait = "0.1.17"
 
 [build-dependencies]
-tonic-build = "0.1.0-alpha.4"
+tonic-build = "0.1.0-alpha.5"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,14 +1,13 @@
 use async_trait::async_trait;
 use crate::error::Error;
 use prost_types::Any;
-use std::fmt;
 
 pub struct Client<T>(T);
 
 impl <T: DaprInterface> Client<T> {
     /// Connect to a Dapr enabled app.
     pub async fn connect(addr: String) -> Result<Self, Error> {
-        T::connect(addr).await.map(Client)
+        Ok(Client(T::connect(addr).await?))
     }
 
     /// Invoke a method in a Dapr enabled app.
@@ -33,31 +32,120 @@ impl <T: DaprInterface> Client<T> {
             .await
 
     }
+
+    /// Invoke an Dapr output binding.
+    pub async fn invoke_binding<S>(&mut self, name: S, data: Option<Any>) -> Result<(), Error>
+    where
+        S: Into<String>,
+    {
+        self.0
+            .invoke_binding(InvokeBindingRequest {
+                name: name.into(),
+                data,
+                ..Default::default()
+            })
+            .await
+    }
+
+    /// Publish a payload to multiple consumers who are listening on a topic.
+    ///
+    /// Dapr guarantees at least once semantics for this endpoint.
+    pub async fn publish_event<S>(&mut self, topic: S, data: Option<Any>) -> Result<(), Error>
+    where
+        S: Into<String>,
+    {
+        self.0
+            .publish_event(PublishEventRequest {
+                topic: topic.into(),
+                data
+            })
+            .await
+    }
+
+
+    /// Get the state for a specific key.
+    pub async fn get_state<S>(&mut self, key: S) -> Result<GetStateResponse, Error>
+    where
+        S: Into<String>,
+    {
+        self.0
+            .get_state(GetStateRequest {
+                key: key.into(),
+                ..Default::default()
+            })
+            .await
+    }
+
+
+    /// Save an array of state objects.
+    pub async fn save_state<I, K>(&mut self, requests: I) -> Result<(), Error>
+    where
+        I: IntoIterator<Item = (K, Option<Any>)>,
+        K: Into<String>,
+    {
+        self.0
+            .save_state(SaveStateRequest {
+                requests: requests.into_iter().map(|pair| pair.into()).collect(),
+            })
+            .await
+    }
+
+    /// Delete the state for a specific key.
+    pub async fn delete_state<S>(&mut self, key: S) -> Result<(), Error>
+    where
+        S: Into<String>,
+    {
+        self.0
+            .delete_state(DeleteStateRequest {
+                key: key.into(),
+                ..Default::default()
+            })
+            .await
+    }
 }
 
 #[async_trait]
 pub trait DaprInterface: std::marker::Sized {
     async fn connect(addr: String) -> Result<Self, Error>;
     async fn invoke_service(&mut self, request: InvokeServiceRequest) -> Result<InvokeServiceResponse, Error>;
+    async fn invoke_binding(&mut self, request: InvokeBindingRequest) -> Result<(), Error>;
+    async fn publish_event(&mut self, request: PublishEventRequest) -> Result<(), Error>;
+    async fn get_state(&mut self, request: GetStateRequest) -> Result<GetStateResponse, Error>;
+    async fn save_state(&mut self, request: SaveStateRequest) -> Result<(), Error>;
+    async fn delete_state(&mut self, request: DeleteStateRequest) -> Result<(), Error>;
 }
 
 
 #[async_trait]
 impl DaprInterface for internal::client::DaprClient<tonic::transport::Channel> {
     async fn connect(addr: String) -> Result<Self, Error> {
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        std::thread::spawn(|| {
-            tx.send(internal::client::DaprClient::connect(addr)).unwrap_or_else(|_| panic!(""));
-        });
-        Ok(rx.await.unwrap_or_else(|_| panic!(""))?)
-
+        Ok(internal::client::DaprClient::connect(addr).await?)
     }
 
     async fn invoke_service(&mut self, request: InvokeServiceRequest) -> Result<InvokeServiceResponse, Error> {
         Ok(self.invoke_service(tonic::Request::new(request)).await?.into_inner())
     }
-}
 
+    async fn invoke_binding(&mut self, request: InvokeBindingRequest) -> Result<(), Error> {
+        Ok(self.invoke_binding(tonic::Request::new(request)).await?.into_inner())
+    }
+
+    async fn publish_event(&mut self, request: PublishEventRequest) -> Result<(), Error> {
+        Ok(self.publish_event(tonic::Request::new(request)).await?.into_inner())
+    }
+
+    async fn get_state(&mut self, request: GetStateRequest) -> Result<GetStateResponse, Error> {
+        Ok(self.get_state(tonic::Request::new(request)).await?.into_inner())
+    }
+
+    async fn save_state(&mut self, request: SaveStateRequest) -> Result<(), Error> {
+        Ok(self.save_state(tonic::Request::new(request)).await?.into_inner())
+    }
+
+    async fn delete_state(&mut self, request: DeleteStateRequest) -> Result<(), Error> {
+        Ok(self.delete_state(tonic::Request::new(request)).await?.into_inner())
+    }
+}
 
 mod internal {
     tonic::include_proto!("dapr");
@@ -65,8 +153,40 @@ mod internal {
 
 /// A request from invoking a service
 pub type InvokeServiceRequest = internal::InvokeServiceEnvelope;
+
 /// A response from invoking a service
 pub type InvokeServiceResponse = internal::InvokeServiceResponseEnvelope;
 
+/// A request from invoking a binding
+pub type InvokeBindingRequest = internal::InvokeBindingEnvelope;
+
+/// A request for publishing event
+pub type PublishEventRequest = internal::PublishEventEnvelope;
+
+/// A request for getting state
+pub type GetStateRequest = internal::GetStateEnvelope;
+
+/// A response from getting state
+pub type GetStateResponse = internal::GetStateResponseEnvelope;
+
+/// A request for saving state
+pub type SaveStateRequest = internal::SaveStateEnvelope;
+
+/// A request for deleting state
+pub type DeleteStateRequest = internal::DeleteStateEnvelope;
+
 /// A tonic based gRPC client
 pub type TonicClient = internal::client::DaprClient<tonic::transport::Channel>;
+
+impl<K> From<(K, Option<Any>)> for internal::StateRequest
+where
+    K: Into<String>,
+{
+    fn from((key, value): (K, Option<Any>)) -> Self {
+        internal::StateRequest {
+            key: key.into(),
+            value: value,
+            ..Default::default()
+        }
+    }
+}


### PR DESCRIPTION
This fills out remaining client functionality. 

I'm not sure `Client` is the right name. Do we have a good sense for what this struct should be called? Especially considering that there will be more code generated from the `daprclient.proto` file, and I'm not sure what to call the struct that wraps that code. 