### PR TITLE
Version bump to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dapr"
-version = "0.5.0-alpha.0"
+version = "0.5.0"
 authors = ["dapr.io"]
 edition = "2018"
 license-file = "LICENSE"


### PR DESCRIPTION
Aligns with Dapr Runtime release 1.1.0.