### PR TITLE
Small pub/sub example doc fix

### DIFF
--- a/examples/pubsub/README.md
+++ b/examples/pubsub/README.md
@@ -23,5 +23,5 @@ dapr run --app-id rust-subscriber --app-protocol grpc --app-port 50051 cargo run
 
 2. Start Publisher:
 ```bash
-dapr run --app-id python-publisher --app-protocol grpc cargo run -- --example publisher
+dapr run --app-id rust-publisher --app-protocol grpc cargo run -- --example publisher
 ```


### PR DESCRIPTION
It appears as if some of the example docs were copied from the python example. This change simply updates the name of the DAPR app in the example 