### PR TITLE
Add Client::invoke_service_http

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -57,6 +57,9 @@ impl<T: DaprInterface> Client<T> {
     ///
     /// * `app_id` - Id of the application running.
     /// * `method_name` - Name of the method to invoke.
+    /// * `http_method` - Http method to use in invoke.
+    /// * `content_type` - Content type to use in invoke.
+    /// * `queries` - Queries to pass in invoke.
     /// * `data` - Required. Bytes value or data required to invoke service.
     pub async fn invoke_service_http<I, M, C, H, QS>(
         &mut self,

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,37 @@ impl<T: DaprInterface> Client<T> {
     /// * `app_id` - Id of the application running.
     /// * `method_name` - Name of the method to invoke.
     /// * `data` - Required. Bytes value or data required to invoke service.
-    pub async fn invoke_service<I, M, C, H, QS>(
+    pub async fn invoke_service<I, M>(
+        &mut self,
+        app_id: I,
+        method_name: M,
+        data: Option<Any>,
+    ) -> Result<InvokeServiceResponse, Error>
+    where
+        I: Into<String>,
+        M: Into<String>,
+    {
+        self.0
+            .invoke_service(InvokeServiceRequest {
+                id: app_id.into(),
+                message: common_v1::InvokeRequest {
+                    method: method_name.into(),
+                    data,
+                    ..Default::default()
+                }
+                .into(),
+            })
+            .await
+    }
+
+    /// Invoke a method in a Dapr enabled app using HTTP.
+    ///
+    /// # Arguments
+    ///
+    /// * `app_id` - Id of the application running.
+    /// * `method_name` - Name of the method to invoke.
+    /// * `data` - Required. Bytes value or data required to invoke service.
+    pub async fn invoke_service_http<I, M, C, H, QS>(
         &mut self,
         app_id: I,
         method_name: M,


### PR DESCRIPTION
Add ability to specify:

1. HTTP method
2. Content-Type
3. Queries

It is currently a very stringly-typed API but I am not sure if there's even an attempt to enumerate all the possible Content-Type.
Other than that, I am not sure if passing the queries directly as a String is correct here, because
we want to utilize stronger correctness with something like Iterator<Item=(String,String)> instead.
But this does give the freedom to the user to decide how they want to allocate the string.

Closes #71 

Signed-off-by: Hanif Ariffin <hanif.ariffin.4326@gmail.com>