### PR TITLE
Update protos, bump to v0.8.0-alpha.0 and fetch protos from corresponding runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dapr"
-version = "0.7.3-alpha.0"
+version = "0.8.0-alpha.0"
 authors = ["dapr.io"]
 edition = "2018"
 license-file = "LICENSE"

--- a/README.md
+++ b/README.md
@@ -56,3 +56,12 @@ cargo build
 ```
 
 >Note: The proto buf client generation is built into `cargo build` process so updating the proto files under `dapr/` is enough to update the proto buf client.
+
+## To refresh .proto files from upstream dapr
+
+1. Just need to run update-protos.sh, which will basically fetch latest proto updates.
+2. By default, it picks from master proto. To specify a particular release/version, please specify with a -v flag
+
+```bash
+./update-protos.sh -v v1.7.0-rc.2
+```

--- a/dapr/proto/runtime/v1/dapr.proto
+++ b/dapr/proto/runtime/v1/dapr.proto
@@ -92,6 +92,9 @@ service Dapr {
   // SubscribeConfiguration gets configuration from configuration store and subscribe the updates event by grpc stream
   rpc SubscribeConfigurationAlpha1(SubscribeConfigurationRequest) returns (stream SubscribeConfigurationResponse) {}
 
+  // UnSubscribeConfiguration unsubscribe the subscription of configuration
+  rpc UnsubscribeConfigurationAlpha1(UnsubscribeConfigurationRequest) returns (UnsubscribeConfigurationResponse) {}
+
   // Gets metadata of the sidecar
   rpc GetMetadata (google.protobuf.Empty) returns (GetMetadataResponse) {}
 
@@ -511,8 +514,25 @@ message SubscribeConfigurationRequest {
   map<string, string> metadata = 3;
 }
 
+// UnSubscribeConfigurationRequest is the message to stop watching the key-value configuration.
+message UnsubscribeConfigurationRequest {
+  // The name of configuration store.
+  string store_name = 1;
+
+  // The id to unsubscribe.
+  string id = 2;
+}
+
 message SubscribeConfigurationResponse {
+  // Subscribe id, used to stop subscription.
+  string id = 1;
+
   // The list of items containing configuration values
-  repeated common.v1.ConfigurationItem items = 1;
+  repeated common.v1.ConfigurationItem items = 2;
+}
+
+message UnsubscribeConfigurationResponse {
+  bool ok = 1;
+  string message = 2;
 }
 

--- a/update-protos.sh
+++ b/update-protos.sh
@@ -18,6 +18,7 @@ APPCALLBACK="appcallback"
 COMMON="common"
 DAPR="dapr"
 RUNTIME="runtime"
+RUNTIME_RELEASE_TAG="master"
 
 # Path to store output
 PROTO_PATH="dapr/proto"
@@ -36,13 +37,33 @@ checkHttpRequestCLI() {
     fi
 }
 
+setRuntimeReleaseTag() {
+    local OPTIND
+    while getopts ":v:" opt; do
+        case $opt in
+            v)
+                echo "Passed Runtime Release Tag is: $OPTARG" >&2
+                RUNTIME_RELEASE_TAG=$OPTARG
+                ;;
+            \?)
+                echo "Invalid option: -$OPTARG" >&2
+                exit 1
+                ;;
+            :)
+                echo "Option -$OPTARG requires an argument." >&2
+                exit 1
+                ;;
+        esac
+    done
+}
+
 downloadFile() {
     FOLDER_NAME=$1
     FILE_NAME=$2
     FILE_PATH="${PROTO_PATH}/${FOLDER_NAME}/v1"
 
     # URL for proto file
-    PROTO_URL="https://raw.githubusercontent.com/dapr/dapr/master/dapr/proto/${FOLDER_NAME}/v1/${FILE_NAME}.proto"
+    PROTO_URL="https://raw.githubusercontent.com/dapr/dapr/${RUNTIME_RELEASE_TAG}/dapr/proto/${FOLDER_NAME}/v1/${FILE_NAME}.proto"
 
     mkdir -p "${FILE_PATH}"
 
@@ -74,6 +95,7 @@ fail_trap() {
 trap "fail_trap" EXIT
 
 checkHttpRequestCLI
+setRuntimeReleaseTag "$@"
 downloadFile $COMMON $COMMON
 downloadFile $RUNTIME $DAPR
 downloadFile $RUNTIME $APPCALLBACK


### PR DESCRIPTION
Signed-off-by: Deepanshu Agarwal <deepanshu.agarwal1984@gmail.com>

Updates protos and bumps to v0.8.0-alpha.0.
Changes to fetch protos from a particular version of runtime in update-protos.sh. If nothing provided, by default picks protos from master.