### PR TITLE
Couple doc updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,17 +107,6 @@ git commit --amend --no-edit --signoff
 git push --force-with-lease <remote-name> <branch-name>
 ```
 
-### Use of Third-party code
-
-- All third-party code must be placed in the `vendor/` folder.
-- `vendor/` folder is managed by Go modules and stores the source code of third-party Go dependencies. - The `vendor/` folder should not be modified manually.
-- Third-party code must include licenses.
-
-A non-exclusive list of code that must be places in `vendor/`:
-
-- Open source, free software, or commercially-licensed code.
-- Tools or libraries or protocols that are open source, free software, or commercially licensed.
-
 **Thank You!** - Your contributions to open source, large or small, make projects like this possible. Thank you for taking the time to contribute.
 
 ### Fork and set upstream

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Dapr is a portable, event-driven, serverless runtime for building distributed ap
 
 Ensure you have Rust version 1.40 or higher installed. If not, install Rust [here](https://www.rust-lang.org/tools/install).
 
+You will also need to install [protoc](https://github.com/protocolbuffers/protobuf#protobuf-compiler-installation).
+
 ## How to use
 
 Add the following to your `Cargo.toml` file:


### PR DESCRIPTION
Two minor suggested updates to the docs:

* Starting in [v0.11](https://github.com/tokio-rs/prost/releases/tag/v0.11.0), `prost` no longer bundles `protoc` and will no longer attempt to download the compiler if one doesn't already exist. Users will need protoc installed to work with the SDK so worth noting that as a pre-req IMO
* The Contributing docs had a reference to using the `vendor` directory for 3rd party Go modules which seemed out of place to me and a potential copy/paste leftover from another repo 

Note that I opted to make these separate commits particularly in case I'm missing some context around that `vendor` directory and 6231e56bc83165c765b9dd02ca5a4b0998771a38 is not desired, but I can certainly squash the changes together if you'd prefer both in a single commit