### PR TITLE
Updating protos for Dapr 1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Dapr is a portable, event-driven, serverless runtime for building distributed ap
 
 ## Prerequisites
 
-Ensure you have Rust version 1.40 or higher installed. If not, install Rust [here]((https://www.rust-lang.org/tools/install)).
+Ensure you have Rust version 1.40 or higher installed. If not, install Rust [here](https://www.rust-lang.org/tools/install).
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -21,18 +21,20 @@ Dapr is a portable, event-driven, serverless runtime for building distributed ap
 - [dapr.io](https://dapr.io)
 - [@DaprDev](https://twitter.com/DaprDev)
 
-## Prerequsites
+## Prerequisites
 
-* [Install Rust > 1.40](https://www.rust-lang.org/tools/install)
+Ensure you have Rust version 1.40 or higher installed. If not, install Rust [here]((https://www.rust-lang.org/tools/install)).
 
-## Usage
+## How to use
+
+Add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-dapr = "0.12.0"
+dapr = "0.13.0"
 ```
 
-A client can be created as follows:
+Here's a basic example to create a client:
 
 ```rust
 use dapr;
@@ -46,25 +48,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut client = dapr::Client::<dapr::client::TonicClient>::connect(addr).await?;
 ```
 
-## Try out examples
+## Explore more examples
 
-[Examples](./examples)
+Browse through more examples to understand the SDK better: [View examples](./examples)
 
 ## Building
 
-To build
+To build the SDK run:
 
 ```bash
 cargo build
 ```
 
->Note: The proto buf client generation is built into `cargo build` process so updating the proto files under `dapr/` is enough to update the proto buf client.
+>Note: The protobuf client generation is built into `cargo build` process so updating the proto files under `dapr/` is enough to update the protobuf client.
 
-## To refresh .proto files from upstream dapr
+## Updating .proto files from upstream Dapr
 
-1. Just need to run update-protos.sh, which will basically fetch latest proto updates.
-2. By default, it picks from master proto. To specify a particular release/version, please specify with a -v flag
+To fetch the latest .proto files from Dapr execute the script `update-protos.sh`:
 
 ```bash
-./update-protos.sh -v v1.10.1
+./update-protos.sh
+```
+
+By default, the script fetches the latest proto updates from the master branch of the Dapr repository. If you need to choose a specific release or version, use the -v flag:
+
+```bash
+./update-protos.sh -v v1.12.0
 ```

--- a/dapr/proto/runtime/v1/dapr.proto
+++ b/dapr/proto/runtime/v1/dapr.proto
@@ -585,6 +585,9 @@ message GetMetadataResponse {
   map<string, string> extended_metadata = 4 [json_name = "extended"];
   repeated PubsubSubscription subscriptions = 5 [json_name = "subscriptions"];
   repeated MetadataHTTPEndpoint http_endpoints = 6 [json_name = "httpEndpoints"];
+  AppConnectionProperties app_connection_properties = 7 [json_name = "appConnectionProperties"];
+  string runtime_version = 8 [json_name = "runtimeVersion"];
+  repeated string enabled_features = 9 [json_name = "enabledFeatures"];
 }
 
 message ActiveActorsCount {
@@ -601,6 +604,21 @@ message RegisteredComponents {
 
 message MetadataHTTPEndpoint {
   string name = 1 [json_name = "name"];
+}
+
+message AppConnectionProperties {
+  int32 port = 1;
+  string protocol = 2;
+  string channel_address = 3 [json_name = "channelAddress"];
+  int32 max_concurrency = 4 [json_name = "maxConcurrency"];
+  AppConnectionHealthProperties health = 5;
+}
+
+message AppConnectionHealthProperties {
+  string health_check_path = 1 [json_name = "healthCheckPath"];
+  string health_probe_interval = 2 [json_name = "healthProbeInterval"];
+  string health_probe_timeout = 3 [json_name = "healthProbeTimeout"];
+  int32 health_threshold = 4 [json_name = "healthThreshold"];
 }
 
 message PubsubSubscription {


### PR DESCRIPTION
Updating protos for Dapr 1.12 (pulling from `master`, since the 1.12 release is not created yet)