### PR TITLE
Add holopin.yml config for GHC2023 event

### DIFF
--- a/.github/holopin.yml
+++ b/.github/holopin.yml
@@ -1,0 +1,6 @@
+organization: dapr
+defaultSticker: clmjkxscc122740fl0mkmb7egi
+stickers:
+  -
+    id: clmjkxscc122740fl0mkmb7egi
+    alias: ghc2023


### PR DESCRIPTION
Add holopin config required to issue badges for the GHC2023 event. For more info see https://github.com/dapr/community/issues/351

