### PR TITLE
Handle metadata for get_configuration and subscribe_configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dapr"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["dapr.io"]
 edition = "2021"
 license-file = "LICENSE"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dapr"
-version = "0.14.1"
+version = "0.14.0"
 authors = ["dapr.io"]
 edition = "2021"
 license-file = "LICENSE"

--- a/examples/configuration/main.rs
+++ b/examples/configuration/main.rs
@@ -20,14 +20,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // save key-value pair in the state store
     let response = client
-        .get_configuration(CONFIGSTORE_NAME, vec![(&key)])
+        .get_configuration(CONFIGSTORE_NAME, vec![(&key)], None)
         .await?;
     let val = response.items.get("hello").unwrap();
     println!("Configuration value: {val:?}");
 
     // Subscribe for configuration changes
     let mut stream = client
-        .subscribe_configuration(CONFIGSTORE_NAME, vec![(&key)])
+        .subscribe_configuration(CONFIGSTORE_NAME, vec![(&key)], Some(metadata))
         .await?;
 
     let mut subscription_id = String::new();

--- a/examples/configuration/main.rs
+++ b/examples/configuration/main.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Subscribe for configuration changes
     let mut stream = client
-        .subscribe_configuration(CONFIGSTORE_NAME, vec![(&key)], Some(metadata))
+        .subscribe_configuration(CONFIGSTORE_NAME, vec![(&key)], None)
         .await?;
 
     let mut subscription_id = String::new();

--- a/src/client.rs
+++ b/src/client.rs
@@ -311,6 +311,7 @@ impl<T: DaprInterface> Client<T> {
         &mut self,
         store_name: S,
         keys: Vec<K>,
+        metadata: Option<HashMap<String, String>>,
     ) -> Result<GetConfigurationResponse, Error>
     where
         S: Into<String>,
@@ -319,7 +320,7 @@ impl<T: DaprInterface> Client<T> {
         let request = GetConfigurationRequest {
             store_name: store_name.into(),
             keys: keys.into_iter().map(|key| key.into()).collect(),
-            metadata: Default::default(),
+            metadata: metadata.unwrap_or_default(),
         };
         self.0.get_configuration(request).await
     }
@@ -329,6 +330,7 @@ impl<T: DaprInterface> Client<T> {
         &mut self,
         store_name: S,
         keys: Vec<S>,
+        metadata: Option<HashMap<String, String>>,
     ) -> Result<Streaming<SubscribeConfigurationResponse>, Error>
     where
         S: Into<String>,
@@ -336,7 +338,7 @@ impl<T: DaprInterface> Client<T> {
         let request = SubscribeConfigurationRequest {
             store_name: store_name.into(),
             keys: keys.into_iter().map(|key| key.into()).collect(),
-            metadata: Default::default(),
+            metadata: metadata.unwrap_or_default(),
         };
         self.0.subscribe_configuration(request).await
     }


### PR DESCRIPTION
This PR would address https://github.com/dapr/rust-sdk/issues/117

Adds a `metadata` parameter to the client's existing `get_configuration` and `subscribe_configuration` implementations. The new `metadata` parameter matches existing function signatures (from `get_state`, for example).

Callers would need to include optional metadata:
```
let mut stream = client
  .subscribe_configuration(CONFIGSTORE_NAME, vec![(&key)], None)
  .await?;
```