### PR TITLE
add github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Report a bug with the Rust SDK
+title: ''
+labels: kind/bug
+assignees: ''
+
+---
+## Expected Behavior
+
+<!-- Briefly describe what you expect to happen -->
+
+
+## Actual Behavior
+
+<!-- Briefly describe what is actually happening -->
+
+
+## Steps to Reproduce the Problem
+
+<!-- How can this issue be reproduced (be detailed) -->
+
+## Release Note
+<!-- How should the fix for this issue be communicated in our release notes? It can be populated later. -->
+<!-- Keep it as a single line. Examples: -->
+<!-- RELEASE NOTE: **ADD** New feature in the Rust SDK. -->
+<!-- RELEASE NOTE: **FIX** Bug in Client. -->
+<!-- RELEASE NOTE: **UPDATE** Client dependencies. -->
+
+RELEASE NOTE:

--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -1,0 +1,8 @@
+---
+name: Discussion
+about: Start a discussion for the Dapr Rust SDK
+title: ''
+labels: kind/discussion
+assignees: ''
+
+---

--- a/.github/ISSUE_TEMPLATE/feature_request_or_proposal.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_or_proposal.md
@@ -1,0 +1,18 @@
+---
+name: Feature Request/Proposal
+about: Create a Feature Request/Proposal for the Rust SDK
+title: ''
+labels: kind/enhancement
+assignees: ''
+
+---
+## Describe the feature/proposal
+
+## Release Note
+<!-- How should this new feature be announced in our release notes? It can be populated later. -->
+<!-- Keep it as a single line. Examples: -->
+<!-- RELEASE NOTE: **ADD** New feature in the Rust SDK. -->
+<!-- RELEASE NOTE: **FIX** Bug in Client. -->
+<!-- RELEASE NOTE: **UPDATE** Client dependencies. -->
+
+RELEASE NOTE:

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,12 @@
+---
+name: Question
+about: Ask a question about the Rust SDK
+title: ''
+labels: kind/question
+assignees: ''
+
+---
+## Question
+
+<!-- Ask your question here -->
+<!-- Include as much information as possible to find an answer quicker :) -->


### PR DESCRIPTION
This PR is non-code related and will add issue templates for the GitHub repo.

Not an RFQ but feedback would be appreciated (open to reviews) on whether you think having a separate template for feature requests/proposals would be a good idea. I think they're almost the same and the standard template across the Dapr ecosystem is a bit lighter if you use the proposal template.

Will close #104 