### PR TITLE
refactor!: adds a port override to the client setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,14 @@ Here's a basic example to create a client:
 use dapr;
 
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Get the Dapr port and create a connection
-    let port: u16 = std::env::var("DAPR_GRPC_PORT")?.parse()?;
-    let addr = format!("https://127.0.0.1:{}", port);
+    // Dapr GRPC Address
+    let addr = "https://127.0.0.1";
+
+    // Dapr GRPC Port (optional)
+    let port = "50001";
 
     // Create the client
-    let mut client = dapr::Client::<dapr::client::TonicClient>::connect(addr).await?;
+    let mut client = dapr::Client::<dapr::client::TonicClient>::connect(addr, port).await?;
 ```
 
 ## Explore more examples

--- a/examples/actors/client.rs
+++ b/examples/actors/client.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "https://127.0.0.1".to_string();
 
     // Create the client
-    let mut client = dapr::Client::<dapr::client::TonicClient>::connect(addr).await?;
+    let mut client = dapr::Client::<dapr::client::TonicClient>::connect(addr, None).await?;
 
     let data = MyRequest {
         name: "test".to_string(),

--- a/examples/client/client.rs
+++ b/examples/client/client.rs
@@ -8,7 +8,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "https://127.0.0.1".to_string();
 
     // Create the client
-    let mut client = dapr::Client::<dapr::client::TonicClient>::connect(addr).await?;
+    let mut client = dapr::Client::<dapr::client::TonicClient>::connect(addr, None).await?;
 
     let key = String::from("hello");
 

--- a/examples/configuration/main.rs
+++ b/examples/configuration/main.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "https://127.0.0.1".to_string();
 
     // Create the client
-    let mut client = DaprClient::connect(addr).await?;
+    let mut client = DaprClient::connect(addr, None).await?;
 
     let key = String::from("hello");
 

--- a/examples/crypto/main.rs
+++ b/examples/crypto/main.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     sleep(std::time::Duration::new(2, 0)).await;
     let addr = "https://127.0.0.1".to_string();
 
-    let mut client = dapr::Client::<dapr::client::TonicClient>::connect(addr).await?;
+    let mut client = dapr::Client::<dapr::client::TonicClient>::connect(addr, None).await?;
 
     let encrypted = client
         .encrypt(

--- a/examples/invoke/grpc/client.rs
+++ b/examples/invoke/grpc/client.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Set the Dapr address
     let address = "https://127.0.0.1".to_string();
 
-    let mut client = DaprClient::connect(address).await?;
+    let mut client = DaprClient::connect(address, None).await?;
 
     let request = HelloRequest {
         name: "Test".to_string(),

--- a/examples/pubsub/publisher.rs
+++ b/examples/pubsub/publisher.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "https://127.0.0.1".to_string();
 
     // Create the client
-    let mut client = dapr::Client::<dapr::client::TonicClient>::connect(addr).await?;
+    let mut client = dapr::Client::<dapr::client::TonicClient>::connect(addr, None).await?;
 
     // name of the pubsub component
     let pubsub_name = "pubsub".to_string();

--- a/examples/query_state/query1.rs
+++ b/examples/query_state/query1.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "https://127.0.0.1".to_string();
 
     // Create the client
-    let mut client = dapr::Client::<dapr::client::TonicClient>::connect(addr).await?;
+    let mut client = dapr::Client::<dapr::client::TonicClient>::connect(addr, None).await?;
 
     let query_condition = json!({
         "filter": {

--- a/examples/query_state/query2.rs
+++ b/examples/query_state/query2.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "https://127.0.0.1".to_string();
 
     // Create the client
-    let mut client = dapr::Client::<dapr::client::TonicClient>::connect(addr).await?;
+    let mut client = dapr::Client::<dapr::client::TonicClient>::connect(addr, None).await?;
 
     let query_condition = json!({
         "filter": {

--- a/examples/secrets-bulk/app.rs
+++ b/examples/secrets-bulk/app.rs
@@ -4,7 +4,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "https://127.0.0.1".to_string();
 
     // Create the client
-    let mut client = dapr::Client::<dapr::client::TonicClient>::connect(addr).await?;
+    let mut client = dapr::Client::<dapr::client::TonicClient>::connect(addr, None).await?;
 
     let secret_store = "localsecretstore";
 


### PR DESCRIPTION
# Description

<!--Please explain the changes you've made here-->

BREAKING CHANGE: You will now be required to specify a port or pass `None` when setting up the client.

The change also adds a default port of 50001 if a port is not passed and there is no `DAPR_GRPC_PORT` env var set.

## Issue reference

<!--We strive to have all PR being opened based on an issue, where the problem or feature should be discussed prior to implementation.-->

<!--Please reference the issue(s) with a hashtag for example #100 -->
This PR will close #NA

## Checklist

<!-- This list is non-exhaustive, please ensure the tests are passing. -->
<!--Please make sure you've completed the relevant tasks for this PR, out of the following list: -->

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
