### PR TITLE
ci: check generated proto output for drift, not just raw protos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ proto-gen:
 
 .PHONY: check-diff-proto
 check-diff-proto:
-	git diff --exit-code ./proto/
+	git diff --exit-code ./proto/ ./dapr/src/dapr/ ./examples/src/invoke/protos/


### PR DESCRIPTION
# Description

`make check-diff-proto` currently only runs `git diff --exit-code ./proto/`, which is the directory of raw `.proto` files downloaded from `dapr/dapr` by `update-protos.sh`. The generated Rust bindings that `proto-gen` emits live in:

- `dapr/src/dapr/` (`dapr.proto.common.v1.rs`, `dapr.proto.runtime.v1.rs`, `types.bin`)
- `examples/src/invoke/protos/` (`helloworld.rs`, `types.bin`)

If either set drifts (hand-edited, or the committed generated code is out of date vs. the tracked `.proto` files), the CI step that runs `make proto-gen check-diff-proto` currently passes — so drift goes undetected.

This PR extends the `check-diff-proto` target to also diff the generated output directories so any change is caught.

## Issue reference

This PR will close #208

## Checklist

* [x] Code compiles correctly — Makefile-only change, no compilation impact
* [x] Created/updated tests — the existing CI step (`make proto-gen check-diff-proto`) is the test; it now actually exercises what the issue asks for
* [ ] Extended the documentation — N/A, no user-facing behavior change