### PR TITLE
fix: stop connect_with_port from panicking on invalid ports

### DIFF
--- a/dapr/src/client/mod.rs
+++ b/dapr/src/client/mod.rs
@@ -71,13 +71,7 @@ impl<T: DaprInterface> Client<T> {
         note = "Will be removed in 0.20.0. Use Client::new() or Client::from_options()."
     )]
     pub async fn connect_with_port(addr: String, port: String) -> Result<Self, Error> {
-        // assert that port is between 1 and 65535
-        let port: u16 = match port.parse::<u16>() {
-            Ok(p) => p,
-            Err(_) => {
-                panic!("Port must be a number between 1 and 65535");
-            }
-        };
+        let port: u16 = port.parse()?;
 
         let address = format!("{addr}:{port}");
 
@@ -1599,6 +1593,23 @@ impl From<ConversationMessageOfTool> for ConversationMessage {
     fn from(msg: ConversationMessageOfTool) -> Self {
         ConversationMessage {
             message_types: Some(conversation_message::MessageTypes::OfTool(msg)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[allow(deprecated)]
+    async fn connect_with_port_returns_parse_error_for_invalid_port() {
+        match Client::<TonicClient>::connect_with_port("http://127.0.0.1".into(), "abc".into())
+            .await
+        {
+            Err(Error::ParseIntError) => {}
+            Err(err) => panic!("expected ParseIntError, got {err:?}"),
+            Ok(_) => panic!("invalid port should return an error"),
         }
     }
 }


### PR DESCRIPTION
# Description

`Client::connect_with_port` returns `Result`, but bad port input still hit a panic. Thats pretty easy to trigger if a caller forwards a string from config or CLI.

Before this patch, this was enough to blow up right away:

```rust
#[allow(deprecated)]
let _ = dapr::Client::<dapr::client::TonicClient>::connect_with_port(
    "http://127.0.0.1".into(),
    "abc".into(),
).await;
```

No cloud quota or hard limit angle here, its just a public fn taking an arbitrary `String`.

This patch returns `Error::ParseIntError` instead, and adds a regression test. Small papercut, clean fix.

## Issue reference

None for this exact panic path.
Related context: #100

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
