### PR TITLE
refactor: use unwrap_or_default for optional metadata maps

### DIFF
--- a/dapr/src/client/mod.rs
+++ b/dapr/src/client/mod.rs
@@ -192,10 +192,7 @@ impl<T: DaprInterface> Client<T> {
     where
         S: Into<String>,
     {
-        let mut mdata = HashMap::<String, String>::new();
-        if let Some(m) = metadata {
-            mdata = m;
-        }
+        let mdata = metadata.unwrap_or_default();
         self.0
             .publish_event(PublishEventRequest {
                 pubsub_name: pubsub_name.into(),
@@ -263,10 +260,7 @@ impl<T: DaprInterface> Client<T> {
     where
         S: Into<String>,
     {
-        let mut mdata = HashMap::<String, String>::new();
-        if let Some(m) = metadata {
-            mdata = m;
-        }
+        let mdata = metadata.unwrap_or_default();
 
         self.0
             .get_state(GetStateRequest {
@@ -347,10 +341,7 @@ impl<T: DaprInterface> Client<T> {
     where
         S: Into<String>,
     {
-        let mut mdata = HashMap::<String, String>::new();
-        if let Some(m) = metadata {
-            mdata = m;
-        }
+        let mdata = metadata.unwrap_or_default();
 
         self.0
             .query_state_alpha1(QueryStateRequest {
@@ -395,10 +386,7 @@ impl<T: DaprInterface> Client<T> {
     where
         S: Into<String>,
     {
-        let mut mdata = HashMap::<String, String>::new();
-        if let Some(m) = metadata {
-            mdata = m;
-        }
+        let mdata = metadata.unwrap_or_default();
 
         self.0
             .delete_state(DeleteStateRequest {
@@ -456,10 +444,7 @@ impl<T: DaprInterface> Client<T> {
         TInput: Serialize,
         TOutput: for<'a> Deserialize<'a>,
     {
-        let mut mdata = HashMap::<String, String>::new();
-        if let Some(m) = metadata {
-            mdata = m;
-        }
+        let mut mdata = metadata.unwrap_or_default();
 
         mdata.insert("Content-Type".to_string(), "application/json".to_string());
 


### PR DESCRIPTION
5 methods in `client/mod.rs` all have the same verbose pattern for handling optional metadata:

```rust
let mut mdata = HashMap::<String, String>::new();
if let Some(m) = metadata {
    mdata = m;
}
```

This is just a roundabout way of writing `metadata.unwrap_or_default()`. Swaps all 5 instances for that. No behavior change - `HashMap::default()` is identical to `HashMap::new()`.

Also removes the unnecessary `mut` on the bindings where the map isn't modified after init (4 out of 5 cases).

To reproduce the pattern before the fix:
```
grep -n "let mut mdata = HashMap" dapr/src/client/mod.rs
```